### PR TITLE
Fetching woo orders

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -122,23 +122,44 @@ function buildErrorCard( header, message ) {
 }
 
 /**
- * Get the sender's email address from a Gmail message.
+ * Get the other party's email address in a Gmail message.
+ * If the sender is the current user's email, return the "To" recipient instead.
  *
- * @param {GmailApp.GmailMessage} message The Gmail message we are looking at.
- * @return {string} The sender's email address.
+ * @param {GmailApp.GmailMessage} message The Gmail message.
+ * @return {string} The customer’s email address.
  */
 function getEmailAddressFromMessage( message ) {
+  const myEmail = Session.getActiveUser().getEmail(); // Your email
   const from = message.getFrom();
+  const to = message.getTo();
 
-  const nameAndEmailInFromMatcher = /[^<>]+/gi;
-  
-  const nameAndEmailMatchResult = from.match( nameAndEmailInFromMatcher );
+  const fromEmail = extractEmailFromString(from);
+  const toEmail = extractEmailFromString(to);
 
-  if ( nameAndEmailMatchResult === null || nameAndEmailMatchResult.length < 2 ) {
-    return from;
+  // If I'm the sender, use the recipient instead
+  if (fromEmail.toLowerCase() === myEmail.toLowerCase()) {
+    return toEmail;
   }
 
-  return nameAndEmailMatchResult[1];
+  return fromEmail;
+}
+
+/**
+ * Extract the email address from a string like "Name <email@example.com>"
+ *
+ * @param {string} emailString
+ * @returns {string}
+ */
+function extractEmailFromString(emailString) {
+  const emailRegex = /<([^>]+)>/;
+  const match = emailString.match(emailRegex);
+
+  if (match && match[1]) {
+    return match[1];
+  }
+
+  // If no angle brackets, return the whole string (e.g. just an email address).
+  return emailString;
 }
 
 /**

--- a/Code.gs
+++ b/Code.gs
@@ -82,6 +82,11 @@ function onGmailMessage( event ) {
  * @returns {CardService.Card}
  */
 function onSearchByEmail(e) {
+
+  if ( ! e || ! e.formInput ) {
+   return buildErrorCard('Invalid Input', 'Form input is missing. Please try again.');
+  }
+
   const emailAddress = e.formInput.searchEmail;
 
   if (!emailAddress) {

--- a/Code.gs
+++ b/Code.gs
@@ -9,7 +9,23 @@ function onHomePage() {
   builder.addSection(
     CardService.newCardSection()
       .setHeader( 'Mini CRM for Woo in Gmail' )
-      .addWidget( buildKeyValueWidget( 'Store URL', getWooCommerceHost() ) )
+      .addWidget(CardService.newDivider())
+        .addWidget( buildKeyValueWidget( 'Store URL', getWooCommerceHost() ) )
+      .addWidget(CardService.newDivider())
+        .addWidget(
+          CardService.newTextInput()
+            .setFieldName('searchEmail')
+            .setTitle('Search by Email')
+        )
+        .addWidget(
+          CardService.newTextButton()
+            .setText('Search Orders')
+            .setOnClickAction(
+              CardService.newAction()
+                .setFunctionName('onSearchByEmail')
+            )
+        )
+      .addWidget(CardService.newDivider())
   );
 
   if  ( ! areWooCommerceCredentialsConfigured() ) {
@@ -57,6 +73,31 @@ function onGmailMessage( event ) {
   const orderDataForEmailAddress = fetchOrdersForEmailAddress( emailAddress );
 
   return buildCustomerCard( emailAddress, orderDataForEmailAddress );
+}
+
+/**
+ * Handle the email search from the homepage.
+ *
+ * @param {Object} e Event object containing form inputs.
+ * @returns {CardService.Card}
+ */
+function onSearchByEmail(e) {
+  const emailAddress = e.formInput.searchEmail;
+
+  if (!emailAddress) {
+    return buildErrorCard('Missing Email', 'Please enter a valid email address.');
+  }
+
+  if ('' === getWooCommerceHost(false)) {
+    return buildErrorCard('Configuration Error', 'You need to configure the WOOCOMMERCE_HOST setting');
+  }
+
+  if (!areWooCommerceCredentialsConfigured()) {
+    return buildErrorCard('Configuration Error', 'You need to set up your WooCommerce API keys');
+  }
+
+  const orderDataForEmailAddress = fetchOrdersForEmailAddress(emailAddress);
+  return buildCustomerCard(emailAddress, orderDataForEmailAddress);
 }
 
 /**

--- a/appsscript.json
+++ b/appsscript.json
@@ -7,7 +7,8 @@
   "oauthScopes": [
     "https://www.googleapis.com/auth/gmail.addons.current.message.readonly",
     "https://www.googleapis.com/auth/gmail.addons.execute",
-    "https://www.googleapis.com/auth/script.external_request"
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/userinfo.email"
   ],
   "urlFetchWhitelist": [
     "https://[YOUR-DOMAIN]/wp-json/wc/v3/"


### PR DESCRIPTION
This PR adds the following changes.

1. A search by email input box that allows the user to search orders by email directly from gmail.
![Screenshot 2025-04-10 at 11 36 13](https://github.com/user-attachments/assets/33d06ff9-5ee1-4a75-b904-1e708446206c)

2. When opening threaded emails and at times you may open an email that the from address is your own email address which causes the search to bring up your own orders. The fix here is to then retrieve the "to" address. Ultimately when you viewing an email thread between you and a specific client, you will always see the orders relevant to that email address. 

This fix adds one additional requirement to the `oauthScopes` which is to have access to the logged in users email account.